### PR TITLE
fixed wrong CCH window list mode (padding problem)

### DIFF
--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -105,8 +105,8 @@ class _CrossCorrHist(object):
         st1_bin_idx_unique = st1_spmat.nonzero()[1]
         st2_bin_idx_unique = st2_spmat.nonzero()[1]
 
-        # needs to correct the bins for the valid mode, because the spiketrains
-        # have unequal t_start
+        # 'valid' mode requires bins correction due to the shift in t_starts
+        # 'full' and 'pad' modes don't need this correction
         if cch_mode == "valid":
             if binned_st1.num_bins > binned_st2.num_bins:
                 st2_bin_idx_unique += right_edge

--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -656,13 +656,13 @@ def cross_correlation_histogram(
 
     t_lags_shift = (binned_st2.t_start - binned_st1.t_start) / binsize
     t_lags_shift = t_lags_shift.simplified.item()
-    if not np.isclose(t_lags_shift, int(t_lags_shift)):
+    if not np.isclose(t_lags_shift, round(t_lags_shift)):
         # For example, if binsize=1 ms, binned_st1.t_start=0 ms, and
         # binned_st2.t_start=0.5 ms then there is a global shift in the
         # binning of the spike trains.
         raise ValueError(
             "Binned spiketrains time shift is not multiple of binsize")
-    t_lags_shift = int(t_lags_shift)
+    t_lags_shift = int(round(t_lags_shift))
 
     # In the examples below we fix st2 and "move" st1.
     # Zero-lag is equal to `max(st1.t_start, st2.t_start)`.

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -496,8 +496,10 @@ class CrossCorrelationHistogramTest(unittest.TestCase):
         cch_win, bin_ids = sc.cch(
             self.binned_st1, self.binned_st2, window=[-30, 30])
         cch_win_mem, bin_ids_mem = sc.cch(
-            self.binned_st1, self.binned_st2, window=[-30, 30])
+            self.binned_st1, self.binned_st2, window=[-30, 30],
+            method='memory')
 
+        self.assertEqual(len(bin_ids), cch_win.shape[0])
         assert_array_equal(bin_ids, np.arange(-30, 31, 1))
         assert_array_equal(
             (bin_ids - 0.5) * self.binned_st1.binsize, cch_win.times)
@@ -623,20 +625,30 @@ class CrossCorrelationHistDifferentTStartTStopTest(unittest.TestCase):
         for window in ('valid', 'full'):
             with self.subTest(msg="window={}".format(window),
                               window=window):
-                st1_binned = conv.BinnedSpikeTrain(st1, binsize=1 * pq.s)
-                st2_binned = conv.BinnedSpikeTrain(st2, binsize=1 * pq.s)
-                cch, bins = sc.cross_correlation_histogram(
+                binsize = 1 * pq.s
+                st1_binned = conv.BinnedSpikeTrain(st1, binsize=binsize)
+                st2_binned = conv.BinnedSpikeTrain(st2, binsize=binsize)
+                t_start_shift = (st2.t_start - st1.t_start) / binsize
+                t_start_shift = int(t_start_shift.simplified.magnitude)
+                left, right = lags_true[window][(0, -1), ] - t_start_shift
+                cch_window, lags_window = sc.cross_correlation_histogram(
+                    st1_binned, st2_binned, window=(left, right)
+                )
+                self.assertEqual(len(lags_window), cch_window.shape[0])
+                cch, lags = sc.cross_correlation_histogram(
                     st1_binned, st2_binned, window=window)
                 cch_memory, _ = sc.cross_correlation_histogram(
                     st1_binned, st2_binned, window=window, method='memory',
                 )
                 assert_array_almost_equal(cch.magnitude, cch_memory.magnitude)
+                assert_array_almost_equal(cch.magnitude, cch_window.magnitude)
                 cch_np = np.correlate(st1_binned.to_array()[0],
                                       st2_binned.to_array()[0],
                                       mode=window)
                 assert_array_almost_equal(np.ravel(cch.magnitude),
                                           cch_np[::-1])
-                assert_array_equal(bins, lags_true[window])
+                assert_array_equal(lags, lags_true[window])
+                assert_array_equal(lags, lags_window)
 
     def test_cross_correlation_histogram_valid_full_overlap(self):
         # ex. 1 in the source code
@@ -645,8 +657,8 @@ class CrossCorrelationHistDifferentTStartTStopTest(unittest.TestCase):
         st2 = neo.SpikeTrain([1.5, 2.5, 4.5, 8.5, 9.5, 10.5]
                              * pq.s, t_start=1 * pq.s, t_stop=13 * pq.s)
         lags_true = {
-            'valid': np.arange(-2, 6),
-            'full': np.arange(-6, 10)
+            'valid': np.arange(-2, 6, dtype=np.int32),
+            'full': np.arange(-6, 10, dtype=np.int32)
         }
         self._run_sub_tests(st1, st2, lags_true)
 
@@ -657,8 +669,8 @@ class CrossCorrelationHistDifferentTStartTStopTest(unittest.TestCase):
         st2 = neo.SpikeTrain([3.5, 5.5, 6.5, 7.5, 8.5] *
                              pq.s, t_start=2 * pq.s, t_stop=9 * pq.s)
         lags_true = {
-            'valid': [1, 2],
-            'full': np.arange(-4, 8)
+            'valid': np.arange(1, 3, dtype=np.int32),
+            'full': np.arange(-4, 8, dtype=np.int32)
         }
         self._run_sub_tests(st1, st2, lags_true)
 
@@ -668,8 +680,8 @@ class CrossCorrelationHistDifferentTStartTStopTest(unittest.TestCase):
         st2 = neo.SpikeTrain([3.5, 5.5, 6.5, 7.5, 8.5] * pq.s + 6 * pq.s,
                              t_start=8 * pq.s, t_stop=15 * pq.s)
         lags_true = {
-            'valid': [7, 8],
-            'full': np.arange(2, 14)
+            'valid': np.arange(7, 9, dtype=np.int32),
+            'full': np.arange(2, 14, dtype=np.int32)
         }
         self._run_sub_tests(st1, st2, lags_true)
 

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -555,7 +555,8 @@ class CrossCorrelationHistogramTest(unittest.TestCase):
         cch_valid, _ = sc.cross_correlation_histogram(
             self.binned_st1, self.binned_st2, window='full',
             border_correction=True, binary=False, kernel=None)
-        valid_lags = sc._get_valid_lags(self.binned_st1, self.binned_st2)
+        valid_lags = sc._CrossCorrHist.get_valid_lags(self.binned_st1,
+                                                      self.binned_st2)
         left_edge, right_edge = valid_lags[(0, -1), ]
         cch_builder = sc._CrossCorrHist(self.binned_st1, self.binned_st2,
                                         window=(left_edge, right_edge))

--- a/elephant/test/test_spike_train_correlation.py
+++ b/elephant/test/test_spike_train_correlation.py
@@ -629,9 +629,7 @@ class CrossCorrelationHistDifferentTStartTStopTest(unittest.TestCase):
                 binsize = 1 * pq.s
                 st1_binned = conv.BinnedSpikeTrain(st1, binsize=binsize)
                 st2_binned = conv.BinnedSpikeTrain(st2, binsize=binsize)
-                t_start_shift = (st2.t_start - st1.t_start) / binsize
-                t_start_shift = int(t_start_shift.simplified.magnitude)
-                left, right = lags_true[window][(0, -1), ] - t_start_shift
+                left, right = lags_true[window][(0, -1), ]
                 cch_window, lags_window = sc.cross_correlation_histogram(
                     st1_binned, st2_binned, window=(left, right)
                 )
@@ -685,6 +683,18 @@ class CrossCorrelationHistDifferentTStartTStopTest(unittest.TestCase):
             'full': np.arange(2, 14, dtype=np.int32)
         }
         self._run_sub_tests(st1, st2, lags_true)
+
+    def test_invalid_time_shift(self):
+        # time shift of 0.4 s is not multiple of binsize=1 s
+        st1 = neo.SpikeTrain([2.5, 3.5] * pq.s, t_start=1 * pq.s,
+                             t_stop=7 * pq.s)
+        st2 = neo.SpikeTrain([3.5, 5.5] * pq.s, t_start=1.4 * pq.s,
+                             t_stop=7.4 * pq.s)
+        binsize = 1 * pq.s
+        st1_binned = conv.BinnedSpikeTrain(st1, binsize=binsize)
+        st2_binned = conv.BinnedSpikeTrain(st2, binsize=binsize)
+        self.assertRaises(ValueError, sc.cross_correlation_histogram,
+                          st1_binned, st2_binned)
 
 
 class SpikeTimeTilingCoefficientTestCase(unittest.TestCase):


### PR DESCRIPTION
When I looked at your PR I spot a regression issue  that I didn't cover last time (now it is) when `window` is a list of ints.
Now I added a test that checks manually provided window-list mode being the same as valid or full mode.
However, the window-list arguments don't account for `t_start_shift` (to be consistent with the code block if `window=='full'`) and I don't know what's more intuitive/correct behavior is (previously, it didn't matter because `t_start_shift` was always zero).
@Kleinjohann please take a look!