### PR TITLE
Enh/asset iteration

### DIFF
--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -391,59 +391,58 @@ def _interpolate_signals(signals, sampling_times, verbose=False):
 def _num_iterations(n, d):
     if d == 1:
         return n
-    else:
-        # Create square matrix with diagonal values equal to 2 to `n`.
-        # Start from row/column with index == 2 to facilitate indexing.
-        count_matrix = np.zeros((n + 1, n + 1), dtype=int)
-        count_matrix[np.diag_indices_from(count_matrix)] = np.array(
-            range(n + 1))
-        count_matrix[0:2, 0:2] = 0
+    if d == 2:
+        # equivalent to np.sum(count_matrix)
+        return n * (n + 1) // 2 - 1
 
-        if d == 2:
-            return np.sum(count_matrix)
-        else:
-            # Accumulate counts of all iterations where the first index
-            # is in the interval `d` to `n`.
-            #
-            # The counts for every level is obtained by accumulating the
-            # `count_matrix`, which is the count of iterations with the first
-            # index between `d` and `n`, when `d` = 2.
-            #
-            # For every value from 3 to `d`...
-            # 1. Define each row `n` in the count matrix as the sum of all rows
-            #    equal or above.
-            # 2. Set all rows above the current value of `d` with zeros.
-            #
-            # Example for `n` = 6 and `d` = 4:
-            #
-            #  d = 2 (start)                d = 3
-            #        count                        count
-            #  n                            n
-            #  2     2  0  0  0  0
-            #  3     0  3  0  0  0    ==>   3     2  3  0  0  0    ==>
-            #  4     0  0  4  0  0          4     2  3  4  0  0
-            #  5     0  0  0  5  0          5     2  3  4  5  0
-            #  6     0  0  0  0  6          6     2  3  4  5  6
-            #
-            #  d = 4
-            #        count
-            #  n
-            #
-            #  4     4  6  4  0  0
-            #  5     6  9  8  5  0
-            #  6     8  12 12 10 6
-            #
-            #  The total number is the sum of the `count_matrix` when `d` has
-            #  the value passed to the function.
-            #
+    # Create square matrix with diagonal values equal to 2 to `n`.
+    # Start from row/column with index == 2 to facilitate indexing.
+    count_matrix = np.zeros((n + 1, n + 1), dtype=int)
+    np.fill_diagonal(count_matrix, np.arange(n + 1))
+    count_matrix[1, 1] = 0
 
-            for cur_d in range(3, d + 1):
-                for cur_n in range(n, 2, -1):
-                    count_matrix[cur_n, :] = np.sum(
-                        count_matrix[:cur_n + 1, :], axis=0)
-                # Set previous `d` level to zeros
-                count_matrix[cur_d - 1, :] = np.zeros(n + 1, dtype=int)
-            return np.sum(count_matrix)
+    # Accumulate counts of all iterations where the first index
+    # is in the interval `d` to `n`.
+    #
+    # The counts for every level is obtained by accumulating the
+    # `count_matrix`, which is the count of iterations with the first
+    # index between `d` and `n`, when `d` = 2.
+    #
+    # For every value from 3 to `d`...
+    # 1. Define each row `n` in the count matrix as the sum of all rows
+    #    equal or above.
+    # 2. Set all rows above the current value of `d` with zeros.
+    #
+    # Example for `n` = 6 and `d` = 4:
+    #
+    #  d = 2 (start)                d = 3
+    #        count                        count
+    #  n                            n
+    #  2     2  0  0  0  0
+    #  3     0  3  0  0  0    ==>   3     2  3  0  0  0    ==>
+    #  4     0  0  4  0  0          4     2  3  4  0  0
+    #  5     0  0  0  5  0          5     2  3  4  5  0
+    #  6     0  0  0  0  6          6     2  3  4  5  6
+    #
+    #  d = 4
+    #        count
+    #  n
+    #
+    #  4     4  6  4  0  0
+    #  5     6  9  8  5  0
+    #  6     8  12 12 10 6
+    #
+    #  The total number is the sum of the `count_matrix` when `d` has
+    #  the value passed to the function.
+    #
+
+    for cur_d in range(3, d + 1):
+        for cur_n in range(n, 2, -1):
+            count_matrix[cur_n, :] = np.sum(count_matrix[:cur_n + 1, :],
+                                            axis=0)
+        # Set previous `d` level to zeros
+        count_matrix[cur_d - 1, :] = np.zeros(n + 1, dtype=int)
+    return np.sum(count_matrix)
 
 
 def _indices_subgenerator(index, range_object, values):

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -388,7 +388,7 @@ def _interpolate_signals(signals, sampling_times, verbose=False):
     return interpolated_signal
 
 
-def num_iterations(n, d):
+def _num_iterations(n, d):
 
     def accumulate_num_iterations(cur_d, max_n):
         if cur_d > 1:
@@ -403,25 +403,25 @@ def num_iterations(n, d):
     return accumulate_num_iterations(d, n)
 
 
-def indices_subgenerator(index, range_object, *values):
+def _indices_subgenerator(index, range_object, *values):
     if index > 1:
         for value in range_object:
             next_index = index - 1
-            yield from indices_subgenerator(next_index,
-                                            range(next_index, value + 1),
-                                            *values, value)
+            yield from _indices_subgenerator(next_index,
+                                             range(next_index, value + 1),
+                                             *values, value)
     else:
         for value in range_object:
             result = *values, value
             yield result
 
 
-def iterate_indices(n, d):
+def _iterate_indices(n, d):
     main_index = range(d, n + 1)
     if d > 1:
         for value in main_index:
             next_index = d - 1
-            yield from indices_subgenerator(
+            yield from _indices_subgenerator(
                 next_index, range(next_index, value + 1), value
             )
     else:
@@ -472,7 +472,7 @@ def _jsf_uniform_orderstat_3d(u, n, verbose=False):
 
     # Define ranges [1,...,n], [2,...,n], ..., [d,...,n] for the mute variables
     # used to compute the integral as a sum over all possibilities
-    it_todo = num_iterations(n, d)
+    it_todo = _num_iterations(n, d)
 
     log_1 = np.log(1.)
     # Compute the log of the integral's coefficient
@@ -505,7 +505,7 @@ def _jsf_uniform_orderstat_3d(u, n, verbose=False):
     # initialise probabilities to 0
     P_total = np.zeros(du.shape[0], dtype=np.float32)
     iter_id = 0
-    for matrix_entries in tqdm(iterate_indices(n, d),
+    for matrix_entries in tqdm(_iterate_indices(n, d),
                                total=it_todo,
                                desc="Joint survival function",
                                disable=not verbose):

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -441,7 +441,7 @@ def _num_iterations(n, d):
             count_matrix[cur_n, :] = np.sum(count_matrix[:cur_n + 1, :],
                                             axis=0)
         # Set previous `d` level to zeros
-        count_matrix[cur_d - 1, :] = np.zeros(n + 1, dtype=int)
+        count_matrix[cur_d - 1, :] = 0
     return np.sum(count_matrix)
 
 
@@ -461,8 +461,8 @@ def _indices_subgenerator(index, range_object, values):
 def _iterate_indices(n, d):
     main_index = range(d, n + 1)
     if d > 1:
+        next_index = d - 1
         for value in main_index:
-            next_index = d - 1
             for i in _indices_subgenerator(next_index,
                                            range(next_index, value + 1),
                                            (value,)):

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -446,17 +446,17 @@ def _num_iterations(n, d):
             return np.sum(count_matrix)
 
 
-def _indices_subgenerator(index, range_object, *values):
+def _indices_subgenerator(index, range_object, values):
     if index > 1:
         for value in range_object:
             next_index = index - 1
             for i in _indices_subgenerator(next_index,
                                            range(next_index, value + 1),
-                                           *values, value):
+                                           values + (value,)):
                 yield i
     else:
         for value in range_object:
-            yield (*values, value)
+            yield values + (value,)
 
 
 def _iterate_indices(n, d):
@@ -466,7 +466,7 @@ def _iterate_indices(n, d):
             next_index = d - 1
             for i in _indices_subgenerator(next_index,
                                            range(next_index, value + 1),
-                                           value):
+                                           (value,)):
                 yield i
     else:
         for value in main_index:

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -455,8 +455,7 @@ def _indices_subgenerator(index, range_object, *values):
                                              *values, value)
     else:
         for value in range_object:
-            result = *values, value
-            yield result
+            yield (*values, value)
 
 
 def _iterate_indices(n, d):

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -450,9 +450,10 @@ def _indices_subgenerator(index, range_object, *values):
     if index > 1:
         for value in range_object:
             next_index = index - 1
-            yield from _indices_subgenerator(next_index,
-                                             range(next_index, value + 1),
-                                             *values, value)
+            for i in _indices_subgenerator(next_index,
+                                           range(next_index, value + 1),
+                                           *values, value):
+                yield i
     else:
         for value in range_object:
             yield (*values, value)
@@ -463,9 +464,10 @@ def _iterate_indices(n, d):
     if d > 1:
         for value in main_index:
             next_index = d - 1
-            yield from _indices_subgenerator(
-                next_index, range(next_index, value + 1), value
-            )
+            for i in _indices_subgenerator(next_index,
+                                           range(next_index, value + 1),
+                                           value):
+                yield i
     else:
         for value in main_index:
             yield value,

--- a/elephant/asset.py
+++ b/elephant/asset.py
@@ -401,12 +401,12 @@ def _num_iterations(n, d):
     np.fill_diagonal(count_matrix, np.arange(n + 1))
     count_matrix[1, 1] = 0
 
-    # Accumulate counts of all iterations where the first index
+    # Accumulate counts of all the iterations where the first index
     # is in the interval `d` to `n`.
     #
     # The counts for every level is obtained by accumulating the
     # `count_matrix`, which is the count of iterations with the first
-    # index between `d` and `n`, when `d` = 2.
+    # index between `d` and `n`, when `d` == 2.
     #
     # For every value from 3 to `d`...
     # 1. Define each row `n` in the count matrix as the sum of all rows
@@ -465,7 +465,7 @@ def _indices_subgenerator(index, range_object, previous_values):
     #          (5,5,4,3)
     #          (5,5,4,4)
     #
-    #          Each of this tuples is passed as `previous_values` when
+    #          Each of these tuples is passed as `previous_values` when
     #          calling `_indices_subgenerator` with `index` = 1. The
     #          `range_object` for this next call will be defined based on the
     #          current value, i.e.:


### PR DESCRIPTION
Improved `_jsf_uniform_orderstat_3d` for speed.

The main loop uses generators to create only the valid indices for the computations, instead of using the cartesian product of the indices' lists and checking for a valid order in each iteration.