### PR TITLE
Update spike_train_correlation.py

### DIFF
--- a/elephant/spike_train_correlation.py
+++ b/elephant/spike_train_correlation.py
@@ -924,29 +924,37 @@ def spike_time_tiling_coefficient(spiketrain_i, spiketrain_j, dt=0.005 * pq.s):
         Calculate the proportion of the total recording time 'tiled' by spikes.
         """
         N = len(spiketrain)
-        time_A = 2 * N * dt  # maximum possible time
+        time_max = 2 * N * dt  # maximum possible time
 
-        if N == 1:  # for just one spike in train
+        if N == 1:  # for only a single spike in the train
+
+            # Check difference between start of recording and single spike
             if spiketrain[0] - spiketrain.t_start < dt:
-                time_A += -dt + spiketrain[0] - spiketrain.t_start
-            if spiketrain[0] + dt > spiketrain.t_stop:
-                time_A += -dt - spiketrain[0] + spiketrain.t_stop
-        else:  # if more than one spike in train
-            # Vectorized loop of spike time differences
+                time_max = time_max - dt + spiketrain[0] - spiketrain.t_start
+
+            # Check difference between single spike and end of recording
+            elif spiketrain[0] + dt > spiketrain.t_stop:
+                time_max = time_max - dt - spiketrain[0] + spiketrain.t_stop
+
+        else:  # if more than a single spike in the train
+
+            # Calculate difference between consecutive spikes
             diff = np.diff(spiketrain)
-            diff_overlap = diff[diff < 2 * dt]
-            # Subtract overlap
-            time_A += -2 * dt * len(diff_overlap) + np.sum(diff_overlap)
 
-            # check if spikes are within dt of the start and/or end
-            # if so subtract overlap of first and/or last spike
+            # Find spikes whose tiles overlap
+            idx = np.where(diff < 2 * dt)[0]
+            # Subtract overlapping "2*dt" tiles and add differences instead
+            time_max = time_max - 2 * dt * len(idx) + diff[idx].sum()
+
+            # Check if spikes are within +/-dt of the start and/or end
+            # if so, subtract overlap of first and/or last spike
             if (spiketrain[0] - spiketrain.t_start) < dt:
-                time_A += spiketrain[0] - dt - spiketrain.t_start
-
+                time_max = time_max + spiketrain[0] - dt - spiketrain.t_start
             if (spiketrain.t_stop - spiketrain[N - 1]) < dt:
-                time_A += -spiketrain[-1] - dt + spiketrain.t_stop
+                time_max = time_max - spiketrain[-1] - dt + spiketrain.t_stop
 
-        T = time_A / (spiketrain.t_stop - spiketrain.t_start)
+        # Calculate the proportion of total recorded time to "tiled" time
+        T = time_max / (spiketrain.t_stop - spiketrain.t_start)
         return T.simplified.item()  # enforce simplification, strip units
 
     N1 = len(spiketrain_i)


### PR DESCRIPTION
Improvement of Spike Time Tiling Coefficient (STTC) calculation by utilizing numpy function.

Details:
-use numpy.where to find overlapping tiles in run_T
-some comments elaborated/changed
-changed name of time_A to time_max for maximum time covered by tiles

This enhancement was inspired by Thierry Nieus code: https://github.com/thierrynieus/Spike-Time-Tiling-Coefficient-