### PR TITLE
Batched-version of Inter-Spike Interval

### DIFF
--- a/elephant/online.py
+++ b/elephant/online.py
@@ -3,6 +3,8 @@ from copy import deepcopy
 import numpy as np
 import quantities as pq
 
+from elephant.statistics import isi
+
 
 class MeanOnline(object):
     def __init__(self, batch_mode=False):
@@ -91,3 +93,54 @@ class VarianceOnline(MeanOnline):
     def reset(self):
         super(VarianceOnline, self).reset()
         self.variance_sum = 0.
+
+
+class InterSpikeIntervalOnline(object):
+    def __init__(self, bin_size=0.0005, max_isi_value=1, batch_mode=False):
+        self.max_isi_value = max_isi_value  # in sec
+        self.last_spike_time = None
+        self.bin_size = bin_size  # in sec
+        self.num_bins = int(self.max_isi_value / self.bin_size)
+        self.bin_edges = np.linspace(start=0, stop=self.max_isi_value,
+                                     num=self.num_bins + 1)
+        self.current_isi_histogram = np.zeros(shape=self.num_bins)
+        self.bach_mode = batch_mode
+        self.units = None
+
+    def update(self, new_val):
+        units = None
+        if isinstance(new_val, pq.Quantity):
+            units = new_val.units
+            new_val = new_val.magnitude
+        if self.last_spike_time is None:  # for first batch
+            if self.bach_mode:
+                new_isi = isi(new_val)
+                self.last_spike_time = new_val[-1]
+            else:
+                new_isi = np.array([])
+                self.last_spike_time = new_val
+            self.units = units
+        else:  # for second to last batch
+            if units != self.units:
+                raise ValueError("Each batch must have the same units.")
+            if self.bach_mode:
+                new_isi = isi(np.append(self.last_spike_time, new_val))
+                self.last_spike_time = new_val[-1]
+            else:
+                new_isi = np.array([new_val - self.last_spike_time])
+                self.last_spike_time = new_val
+        isi_hist, _ = np.histogram(new_isi, bins=self.bin_edges)
+        self.current_isi_histogram += isi_hist
+
+    def as_units(self, val):
+        if self.units is None:
+            return val
+        return pq.Quantity(val, units=self.units, copy=False)
+
+    def get_isi(self):
+        return self.as_units(deepcopy(self.current_isi_histogram))
+
+    def reset(self):
+        self.last_spike_time = None
+        self.units = None
+        self.current_isi_histogram = np.zeros(shape=self.num_bins)

--- a/elephant/test/test_online.py
+++ b/elephant/test/test_online.py
@@ -5,7 +5,7 @@ import quantities as pq
 from numpy.testing import assert_array_almost_equal
 
 from elephant import statistics
-from elephant.online import MeanOnline, VarianceOnline
+from elephant.online import MeanOnline, VarianceOnline, InterSpikeIntervalOnline
 from elephant.spike_train_generation import homogeneous_poisson_process
 from elephant.spike_train_synchrony import spike_contrast
 
@@ -231,6 +231,72 @@ class TestVarianceOnline(unittest.TestCase):
         cv_online = isi_std / isi_mean
         self.assertAlmostEqual(cv_online, cv_target, places=3)
 
+
+class TestInterSpikeIntervalOnline(unittest.TestCase):
+    def test_single_floats(self):
+        np.random.seed(0)
+        arr = np.sort(np.random.rand(100))
+        online_isi = InterSpikeIntervalOnline()
+        for val in arr:
+            online_isi.update(val)
+        self.assertIsNone(online_isi.units)
+        standard_isi_histo, _ = np.histogram(statistics.isi(arr),
+                                             bins=online_isi.bin_edges)
+        np.testing.assert_allclose(online_isi.get_isi(), standard_isi_histo,
+                                   rtol=1e-15, atol=1e-15)
+
+    def test_numpy_array(self):
+        np.random.seed(1)
+        arr = np.sort(np.random.rand(10 * 100)).reshape(10, 100)
+        online_isi = InterSpikeIntervalOnline(batch_mode=True)
+        for arr_vec in arr:
+            online_isi.update(arr_vec)
+        self.assertIsNone(online_isi.units)
+        standard_isi_histo, _ = np.histogram(
+            statistics.isi(arr.reshape(1, 10*100)), bins=online_isi.bin_edges)
+        np.testing.assert_allclose(online_isi.get_isi(), standard_isi_histo,
+                                   rtol=1e-15, atol=1e-15)
+
+    def test_quantity_scalar(self):
+        np.random.seed(2)
+        arr = np.sort(np.random.rand(100)) * pq.s
+        online_isi = InterSpikeIntervalOnline()
+        for val in arr:
+            online_isi.update(val)
+        self.assertEqual(online_isi.units, arr.units)
+        standard_isi_histo, _ = np.histogram(statistics.isi(arr),
+                                             bins=online_isi.bin_edges)
+        np.testing.assert_allclose(online_isi.get_isi().magnitude,
+                                   standard_isi_histo, rtol=1e-15, atol=1e-15)
+
+    def test_quantities_vector(self):
+        np.random.seed(3)
+        arr = np.sort(np.random.rand(10 * 100)).reshape(10, 100) * pq.s
+        online_isi = InterSpikeIntervalOnline(batch_mode=True)
+        for arr_vec in arr:
+            online_isi.update(arr_vec)
+        self.assertEqual(online_isi.units, arr.units)
+        standard_isi_histo, _ = np.histogram(
+            statistics.isi(arr.reshape(1, 10 * 100)), bins=online_isi.bin_edges)
+        np.testing.assert_allclose(online_isi.get_isi().magnitude,
+                                   standard_isi_histo, rtol=1e-15, atol=1e-15)
+
+    def test_reset(self):
+        np.random.seed(4)
+        arr = np.sort(np.random.rand(100)) * pq.s
+        online_isi = InterSpikeIntervalOnline()
+        for val in arr:
+            online_isi.update(val)
+        self.assertEqual(online_isi.units, arr.units)
+        standard_isi_histo, _ = np.histogram(statistics.isi(arr),
+                                             bins=online_isi.bin_edges)
+        np.testing.assert_allclose(online_isi.get_isi().magnitude,
+                                   standard_isi_histo, rtol=1e-15, atol=1e-15)
+        online_isi.reset()
+        self.assertIsNone(online_isi.units)
+        self.assertIsNone(online_isi.last_spike_time)
+        np.testing.assert_allclose(online_isi.current_isi_histogram,
+                                   np.zeros(shape=online_isi.num_bins))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This branch introduces a batched version of the Inter-Spike Interval (ISI). It can be used for online analysis of spiketrains, meaning that it continuously updates an count-histogram of the observed ISI values.
The implementation style itself and  the validation style of the UnitTests was continued from the already existing classes  MeanOnline  and VarianceOnline.