### PR TITLE
Enh/iss101

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -51,6 +51,8 @@ contribution, and may not be the current affiliation of a contributor.
 * Florian Porrmann [13]
 * Sarah Pilz [13]
 * Oliver Kloß [1]
+* Jonas Oberste-Frielinghaus [1]
+* Sven Krausse [1]
 
 1. Institute of Neuroscience and Medicine (INM-6) and Institute for Advanced Simulation (IAS-6) and JARA-Institute Brain Structure-Function Relationships (INM-10), Jülich Research Centre, Jülich, Germany
 2. Unité de Neurosciences, Information et Complexité, CNRS UPR 3293, Gif-sur-Yvette, France

--- a/elephant/spike_train_synchrony.py
+++ b/elephant/spike_train_synchrony.py
@@ -397,10 +397,12 @@ class Synchrotool(Complexity):
         ``self.epoch.array_annotations`` *in-place*.
         """
         epoch_complexities = self.epoch.array_annotations['complexity']
+        bin_shift = .5 / self.sampling_rate
         right_edges = (
             self.epoch.times.magnitude.flatten()
             + self.epoch.durations.rescale(
                 self.epoch.times.units).magnitude.flatten()
+            + bin_shift.rescale(self.epoch.times.units).magnitude
         )
 
         for idx, st in enumerate(self.input_spiketrains):


### PR DESCRIPTION
We corrected the annotation in the Synchrotool to re-shift the right edges of the times of the epochs. 